### PR TITLE
Add retro-styled game hub and Flappy Bird

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Testing-Environment
+# Testing-Environment Game Hub
+
+This repository provides a simple Python game hub built with [Pygame](https://www.pygame.org/). It includes a landing page with a retro 70's styled title and menu where you can select from available games. The hub ships with **Snake** and **Flappy Bird**, both supporting keyboard controls and USB controllers like the Sony DualShock 3.
+
+## Requirements
+- Python 3
+- Pygame
+
+Install dependencies using:
+
+```bash
+pip install pygame
+```
+
+## Usage
+Run the hub with:
+
+```bash
+python gamehub.py
+```
+
+Use the arrow keys or a connected controller to navigate the menu. Select *Snake* or *Flappy Bird* to start a game. During play, use either the keyboard or the controller. After a game over, press Enter or any controller button to return to the hub.
+
+The hub is designed to make it easy to add more games in the future by appending them to the `games` list in `gamehub.py`.

--- a/gamehub.py
+++ b/gamehub.py
@@ -1,0 +1,90 @@
+import sys
+import pygame
+
+from games.snake import run as run_snake
+from games.flappy import run as run_flappy
+
+WIDTH, HEIGHT = 640, 480
+
+# Retro 70's palette
+MENU_BG = (58, 45, 47)
+STRIPE_COLORS = [(249, 200, 14), (255, 127, 17), (214, 48, 49)]
+TITLE_COLOR = (249, 200, 14)
+TEXT_COLOR = (255, 127, 17)
+HIGHLIGHT_COLOR = (255, 221, 0)
+
+
+def init_joysticks():
+    """Initialise all connected joysticks."""
+    pygame.joystick.init()
+    joysticks = []
+    for i in range(pygame.joystick.get_count()):
+        joystick = pygame.joystick.Joystick(i)
+        joystick.init()
+        joysticks.append(joystick)
+    return joysticks
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    pygame.display.set_caption("Game Hub")
+    clock = pygame.time.Clock()
+    title_font = pygame.font.SysFont(None, 72)
+    font = pygame.font.SysFont(None, 48)
+
+    games = [("Snake", run_snake), ("Flappy Bird", run_flappy)]
+    selected = 0
+
+    joysticks = init_joysticks()
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_DOWN, pygame.K_s):
+                    selected = (selected + 1) % len(games)
+                elif event.key in (pygame.K_UP, pygame.K_w):
+                    selected = (selected - 1) % len(games)
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    games[selected][1]()
+                    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+                    joysticks = init_joysticks()
+            elif event.type == pygame.JOYHATMOTION:
+                if event.value[1] == -1:
+                    selected = (selected + 1) % len(games)
+                elif event.value[1] == 1:
+                    selected = (selected - 1) % len(games)
+            elif event.type == pygame.JOYBUTTONDOWN:
+                games[selected][1]()
+                screen = pygame.display.set_mode((WIDTH, HEIGHT))
+                joysticks = init_joysticks()
+
+        screen.fill(MENU_BG)
+
+        # Decorative retro stripes
+        for i, color in enumerate(STRIPE_COLORS):
+            pygame.draw.rect(screen, color, (0, i * 20, WIDTH, 20))
+
+        # Title
+        title = title_font.render("Game Hub", True, TITLE_COLOR)
+        title_rect = title.get_rect(center=(WIDTH // 2, HEIGHT // 3 - 60))
+        screen.blit(title, title_rect)
+
+        for idx, (name, _) in enumerate(games):
+            color = HIGHLIGHT_COLOR if idx == selected else TEXT_COLOR
+            text = font.render(name, True, color)
+            rect = text.get_rect(center=(WIDTH // 2, HEIGHT // 2 + idx * 60))
+            screen.blit(text, rect)
+
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/games/flappy.py
+++ b/games/flappy.py
@@ -1,0 +1,99 @@
+import random
+import sys
+import pygame
+
+WIDTH, HEIGHT = 400, 600
+BIRD_COLOR = (255, 255, 0)
+PIPE_COLOR = (0, 255, 0)
+BACKGROUND = (0, 0, 0)
+
+
+def run():
+    """Run a minimal Flappy Bird clone controllable via keyboard or joystick."""
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    pygame.display.set_caption("Flappy Bird")
+    clock = pygame.time.Clock()
+
+    # Initialise joysticks
+    pygame.joystick.init()
+    for i in range(pygame.joystick.get_count()):
+        pygame.joystick.Joystick(i).init()
+
+    bird = pygame.Rect(50, HEIGHT // 2, 30, 30)
+    velocity = 0
+    gravity = 0.5
+    jump = -8
+
+    pipes = []
+    pipe_gap = 150
+    pipe_speed = 3
+    spawn_timer = 0
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN and event.key in (pygame.K_SPACE, pygame.K_UP):
+                velocity = jump
+            elif event.type == pygame.JOYBUTTONDOWN:
+                velocity = jump
+
+        spawn_timer += 1
+        if spawn_timer > 90:
+            spawn_timer = 0
+            center = random.randrange(100, HEIGHT - 100)
+            top = pygame.Rect(WIDTH, 0, 50, center - pipe_gap // 2)
+            bottom = pygame.Rect(WIDTH, center + pipe_gap // 2, 50, HEIGHT - (center + pipe_gap // 2))
+            pipes.append((top, bottom))
+
+        velocity += gravity
+        bird.y += int(velocity)
+
+        for top, bottom in pipes:
+            top.x -= pipe_speed
+            bottom.x -= pipe_speed
+        pipes = [p for p in pipes if p[0].right > 0]
+
+        for top, bottom in pipes:
+            if bird.colliderect(top) or bird.colliderect(bottom):
+                running = False
+        if bird.top < 0 or bird.bottom > HEIGHT:
+            running = False
+
+        screen.fill(BACKGROUND)
+        pygame.draw.rect(screen, BIRD_COLOR, bird)
+        for top, bottom in pipes:
+            pygame.draw.rect(screen, PIPE_COLOR, top)
+            pygame.draw.rect(screen, PIPE_COLOR, bottom)
+        pygame.display.flip()
+
+        clock.tick(60)
+
+    game_over(screen, clock)
+
+
+def game_over(screen, clock):
+    """Display a game over screen waiting for user input."""
+    font = pygame.font.SysFont(None, 48)
+    msg = font.render("Game Over - Press Enter or Button", True, (255, 255, 255))
+    rect = msg.get_rect(center=(WIDTH // 2, HEIGHT // 2))
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    waiting = False
+            elif event.type == pygame.JOYBUTTONDOWN:
+                waiting = False
+
+        screen.fill((0, 0, 0))
+        screen.blit(msg, rect)
+        pygame.display.flip()
+        clock.tick(15)
+

--- a/games/snake.py
+++ b/games/snake.py
@@ -1,0 +1,148 @@
+import random
+import sys
+import pygame
+
+CELL_SIZE = 20
+GRID_WIDTH = 30
+GRID_HEIGHT = 30
+SCREEN_WIDTH = CELL_SIZE * GRID_WIDTH
+SCREEN_HEIGHT = CELL_SIZE * GRID_HEIGHT
+BACKGROUND = (0, 0, 0)
+SNAKE_COLOR = (0, 255, 0)
+FOOD_COLOR = (255, 0, 0)
+
+
+# Mapping of opposite directions to avoid reversal
+OPPOSITES = {
+    (1, 0): (-1, 0),
+    (-1, 0): (1, 0),
+    (0, 1): (0, -1),
+    (0, -1): (0, 1),
+}
+
+
+def run():
+    """Run a simple snake game controlled by keyboard or joystick."""
+    screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+    pygame.display.set_caption("Snake")
+    clock = pygame.time.Clock()
+
+    # Initialise joysticks
+    pygame.joystick.init()
+    joysticks = []
+    for i in range(pygame.joystick.get_count()):
+        js = pygame.joystick.Joystick(i)
+        js.init()
+        joysticks.append(js)
+
+    snake = [(GRID_WIDTH // 2, GRID_HEIGHT // 2)]
+    direction = (1, 0)
+    food = (random.randrange(GRID_WIDTH), random.randrange(GRID_HEIGHT))
+
+    alive = True
+    while alive:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_UP, pygame.K_w):
+                    new_dir = (0, -1)
+                elif event.key in (pygame.K_DOWN, pygame.K_s):
+                    new_dir = (0, 1)
+                elif event.key in (pygame.K_LEFT, pygame.K_a):
+                    new_dir = (-1, 0)
+                elif event.key in (pygame.K_RIGHT, pygame.K_d):
+                    new_dir = (1, 0)
+                else:
+                    new_dir = direction
+                if new_dir != OPPOSITES.get(direction):
+                    direction = new_dir
+            elif event.type == pygame.JOYHATMOTION:
+                x, y = event.value
+                if x == 1:
+                    new_dir = (1, 0)
+                elif x == -1:
+                    new_dir = (-1, 0)
+                elif y == 1:
+                    new_dir = (0, 1)
+                elif y == -1:
+                    new_dir = (0, -1)
+                else:
+                    new_dir = direction
+                if new_dir != OPPOSITES.get(direction):
+                    direction = new_dir
+            elif event.type == pygame.JOYAXISMOTION:
+                if event.axis == 0:
+                    if event.value > 0.5:
+                        new_dir = (1, 0)
+                    elif event.value < -0.5:
+                        new_dir = (-1, 0)
+                    else:
+                        new_dir = direction
+                elif event.axis == 1:
+                    if event.value > 0.5:
+                        new_dir = (0, 1)
+                    elif event.value < -0.5:
+                        new_dir = (0, -1)
+                    else:
+                        new_dir = direction
+                else:
+                    new_dir = direction
+                if new_dir != OPPOSITES.get(direction):
+                    direction = new_dir
+
+        # Move snake
+        head_x, head_y = snake[0]
+        new_head = ((head_x + direction[0]) % GRID_WIDTH,
+                    (head_y + direction[1]) % GRID_HEIGHT)
+
+        if new_head in snake:
+            alive = False
+            break
+        snake.insert(0, new_head)
+
+        if new_head == food:
+            while food in snake:
+                food = (random.randrange(GRID_WIDTH), random.randrange(GRID_HEIGHT))
+        else:
+            snake.pop()
+
+        # Draw
+        screen.fill(BACKGROUND)
+        for x, y in snake:
+            rect = pygame.Rect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE)
+            pygame.draw.rect(screen, SNAKE_COLOR, rect)
+        fx, fy = food
+        food_rect = pygame.Rect(fx * CELL_SIZE, fy * CELL_SIZE, CELL_SIZE, CELL_SIZE)
+        pygame.draw.rect(screen, FOOD_COLOR, food_rect)
+        pygame.display.flip()
+
+        clock.tick(10)
+
+    game_over(screen, clock)
+
+
+def game_over(screen, clock):
+    """Display a game over screen waiting for user input."""
+    font = pygame.font.SysFont(None, 48)
+    msg = font.render("Game Over - Press Enter or Button", True, (255, 255, 255))
+    rect = msg.get_rect(center=(SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2))
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    waiting = False
+            elif event.type == pygame.JOYBUTTONDOWN:
+                waiting = False
+
+        screen.fill((0, 0, 0))
+        screen.blit(msg, rect)
+        pygame.display.flip()
+        clock.tick(15)
+


### PR DESCRIPTION
## Summary
- restyle landing page with a 70s palette, stripes, and title
- add Flappy Bird game with keyboard/controller support
- document new game and retro hub in README

## Testing
- `python -m py_compile gamehub.py games/snake.py games/flappy.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0af572f748326af5710280c97f95a