### PR TITLE
Add retro game hub with Checkers and text-fit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Testing-Environment
+# Testing-Environment Game Hub
+
+This repository provides a simple Python game hub built with [Pygame](https://www.pygame.org/). It includes a landing page with a retro 70's styled title and menu where you can select from available games. The hub ships with **Snake**, **Flappy Bird**, and **Checkers**, all supporting keyboard controls and USB controllers like the Sony DualShock 3.
+
+## Requirements
+- Python 3
+- Pygame
+
+Install dependencies using:
+
+```bash
+pip install pygame
+```
+
+## Usage
+Run the hub with:
+
+```bash
+python gamehub.py
+```
+
+Use the arrow keys or a connected controller to navigate the menu. Select *Snake*, *Flappy Bird*, or *Checkers* to start a game. During play, use either the keyboard or the controller. After a game over, press Enter or any controller button to return to the hub.
+
+The hub is designed to make it easy to add more games in the future by appending them to the `games` list in `gamehub.py`.

--- a/gamehub.py
+++ b/gamehub.py
@@ -1,0 +1,91 @@
+import sys
+import pygame
+
+from games.snake import run as run_snake
+from games.flappy import run as run_flappy
+from games.checkers import run as run_checkers
+
+WIDTH, HEIGHT = 640, 480
+
+# Retro 70's palette
+MENU_BG = (58, 45, 47)
+STRIPE_COLORS = [(249, 200, 14), (255, 127, 17), (214, 48, 49)]
+TITLE_COLOR = (249, 200, 14)
+TEXT_COLOR = (255, 127, 17)
+HIGHLIGHT_COLOR = (255, 221, 0)
+
+
+def init_joysticks():
+    """Initialise all connected joysticks."""
+    pygame.joystick.init()
+    joysticks = []
+    for i in range(pygame.joystick.get_count()):
+        joystick = pygame.joystick.Joystick(i)
+        joystick.init()
+        joysticks.append(joystick)
+    return joysticks
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    pygame.display.set_caption("Game Hub")
+    clock = pygame.time.Clock()
+    title_font = pygame.font.SysFont(None, 72)
+    font = pygame.font.SysFont(None, 48)
+
+    games = [("Snake", run_snake), ("Flappy Bird", run_flappy), ("Checkers", run_checkers)]
+    selected = 0
+
+    joysticks = init_joysticks()
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_DOWN, pygame.K_s):
+                    selected = (selected + 1) % len(games)
+                elif event.key in (pygame.K_UP, pygame.K_w):
+                    selected = (selected - 1) % len(games)
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    games[selected][1]()
+                    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+                    joysticks = init_joysticks()
+            elif event.type == pygame.JOYHATMOTION:
+                if event.value[1] == -1:
+                    selected = (selected + 1) % len(games)
+                elif event.value[1] == 1:
+                    selected = (selected - 1) % len(games)
+            elif event.type == pygame.JOYBUTTONDOWN:
+                games[selected][1]()
+                screen = pygame.display.set_mode((WIDTH, HEIGHT))
+                joysticks = init_joysticks()
+
+        screen.fill(MENU_BG)
+
+        # Decorative retro stripes
+        for i, color in enumerate(STRIPE_COLORS):
+            pygame.draw.rect(screen, color, (0, i * 20, WIDTH, 20))
+
+        # Title
+        title = title_font.render("Game Hub", True, TITLE_COLOR)
+        title_rect = title.get_rect(center=(WIDTH // 2, HEIGHT // 3 - 60))
+        screen.blit(title, title_rect)
+
+        for idx, (name, _) in enumerate(games):
+            color = HIGHLIGHT_COLOR if idx == selected else TEXT_COLOR
+            text = font.render(name, True, color)
+            rect = text.get_rect(center=(WIDTH // 2, HEIGHT // 2 + idx * 60))
+            screen.blit(text, rect)
+
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/games/checkers.py
+++ b/games/checkers.py
@@ -1,0 +1,189 @@
+import sys
+import pygame
+
+WIDTH = HEIGHT = 480
+ROWS = COLS = 8
+SQUARE_SIZE = WIDTH // COLS
+
+LIGHT = (222, 184, 135)
+DARK = (139, 69, 19)
+RED = (255, 0, 0)
+BLACK = (0, 0, 0)
+HIGHLIGHT = (0, 255, 0)
+
+
+def create_board():
+    board = [[None for _ in range(COLS)] for _ in range(ROWS)]
+    for y in range(3):
+        for x in range(COLS):
+            if (x + y) % 2 == 1:
+                board[y][x] = ["black", False]
+    for y in range(ROWS - 3, ROWS):
+        for x in range(COLS):
+            if (x + y) % 2 == 1:
+                board[y][x] = ["red", False]
+    return board
+
+
+def valid_moves(board, x, y):
+    color, king = board[y][x]
+    moves = {}
+    directions = [(-1, -1), (1, -1)] if color == "red" else [(-1, 1), (1, 1)]
+    if king:
+        directions = [(-1, -1), (1, -1), (-1, 1), (1, 1)]
+    for dx, dy in directions:
+        nx, ny = x + dx, y + dy
+        if 0 <= nx < COLS and 0 <= ny < ROWS:
+            if board[ny][nx] is None:
+                moves[(nx, ny)] = None
+            elif board[ny][nx][0] != color:
+                jx, jy = nx + dx, ny + dy
+                if 0 <= jx < COLS and 0 <= jy < ROWS and board[jy][jx] is None:
+                    moves[(jx, jy)] = (nx, ny)
+    return moves
+
+
+def has_pieces(board, color):
+    for row in board:
+        for piece in row:
+            if piece and piece[0] == color:
+                return True
+    return False
+
+
+def run():
+    """Simple two-player checkers controllable via keyboard or joystick."""
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    pygame.display.set_caption("Checkers")
+    clock = pygame.time.Clock()
+
+    pygame.joystick.init()
+    for i in range(pygame.joystick.get_count()):
+        pygame.joystick.Joystick(i).init()
+
+    board = create_board()
+    cursor = [0, 0]
+    selected = None
+    turn = "red"
+    winner = ""
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_LEFT, pygame.K_a):
+                    cursor[0] = max(0, cursor[0] - 1)
+                elif event.key in (pygame.K_RIGHT, pygame.K_d):
+                    cursor[0] = min(COLS - 1, cursor[0] + 1)
+                elif event.key in (pygame.K_UP, pygame.K_w):
+                    cursor[1] = max(0, cursor[1] - 1)
+                elif event.key in (pygame.K_DOWN, pygame.K_s):
+                    cursor[1] = min(ROWS - 1, cursor[1] + 1)
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    selected, turn = handle_move(board, cursor, selected, turn)
+            elif event.type == pygame.JOYHATMOTION:
+                dx, dy = event.value
+                if dx == -1:
+                    cursor[0] = max(0, cursor[0] - 1)
+                elif dx == 1:
+                    cursor[0] = min(COLS - 1, cursor[0] + 1)
+                if dy == -1:
+                    cursor[1] = max(0, cursor[1] - 1)
+                elif dy == 1:
+                    cursor[1] = min(ROWS - 1, cursor[1] + 1)
+            elif event.type == pygame.JOYBUTTONDOWN:
+                selected, turn = handle_move(board, cursor, selected, turn)
+
+        # Drawing
+        for y in range(ROWS):
+            for x in range(COLS):
+                rect = pygame.Rect(x * SQUARE_SIZE, y * SQUARE_SIZE, SQUARE_SIZE, SQUARE_SIZE)
+                color = LIGHT if (x + y) % 2 == 0 else DARK
+                pygame.draw.rect(screen, color, rect)
+
+                piece = board[y][x]
+                if piece:
+                    pcolor = RED if piece[0] == "red" else BLACK
+                    pygame.draw.circle(screen, pcolor, rect.center, SQUARE_SIZE // 2 - 5)
+                    if piece[1]:
+                        pygame.draw.circle(screen, HIGHLIGHT, rect.center, SQUARE_SIZE // 2 - 20, 2)
+
+        # highlight cursor
+        cursor_rect = pygame.Rect(cursor[0] * SQUARE_SIZE, cursor[1] * SQUARE_SIZE, SQUARE_SIZE, SQUARE_SIZE)
+        pygame.draw.rect(screen, HIGHLIGHT, cursor_rect, 3)
+
+        # highlight selected piece moves
+        if selected:
+            moves = valid_moves(board, selected[0], selected[1])
+            for (mx, my) in moves:
+                move_rect = pygame.Rect(mx * SQUARE_SIZE, my * SQUARE_SIZE, SQUARE_SIZE, SQUARE_SIZE)
+                pygame.draw.rect(screen, HIGHLIGHT, move_rect, 3)
+
+        # show turn
+        font = pygame.font.SysFont(None, 24)
+        text = font.render(f"Turn: {turn.title()}", True, (255, 255, 255))
+        screen.blit(text, (10, 10))
+
+        pygame.display.flip()
+        clock.tick(30)
+
+        # check win
+        if not has_pieces(board, "red"):
+            running = False
+            winner = "Black"
+        elif not has_pieces(board, "black"):
+            running = False
+            winner = "Red"
+
+    game_over(screen, clock, winner)
+
+
+def handle_move(board, cursor, selected, turn):
+    x, y = cursor
+    if selected is None and board[y][x] and board[y][x][0] == turn:
+        selected = (x, y)
+    elif selected:
+        moves = valid_moves(board, selected[0], selected[1])
+        if (x, y) in moves:
+            sx, sy = selected
+            board[y][x] = board[sy][sx]
+            board[sy][sx] = None
+            if moves[(x, y)]:
+                jx, jy = moves[(x, y)]
+                board[jy][jx] = None
+            if (turn == "red" and y == 0) or (turn == "black" and y == ROWS - 1):
+                board[y][x][1] = True
+            selected = None
+            turn = "black" if turn == "red" else "red"
+    return selected, turn
+
+
+def game_over(screen, clock, winner):
+    font_size = 48
+    font = pygame.font.SysFont(None, font_size)
+    msg = font.render(f"{winner} Wins - Press Enter or Button", True, (255, 255, 255))
+    while msg.get_width() > WIDTH - 20 and font_size > 10:
+        font_size -= 2
+        font = pygame.font.SysFont(None, font_size)
+        msg = font.render(f"{winner} Wins - Press Enter or Button", True, (255, 255, 255))
+    rect = msg.get_rect(center=(WIDTH // 2, HEIGHT // 2))
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN and event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                waiting = False
+            elif event.type == pygame.JOYBUTTONDOWN:
+                waiting = False
+
+        screen.fill((0, 0, 0))
+        screen.blit(msg, rect)
+        pygame.display.flip()
+        clock.tick(15)
+

--- a/games/flappy.py
+++ b/games/flappy.py
@@ -1,0 +1,104 @@
+import random
+import sys
+import pygame
+
+WIDTH, HEIGHT = 400, 600
+BIRD_COLOR = (255, 255, 0)
+PIPE_COLOR = (0, 255, 0)
+BACKGROUND = (0, 0, 0)
+
+
+def run():
+    """Run a minimal Flappy Bird clone controllable via keyboard or joystick."""
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    pygame.display.set_caption("Flappy Bird")
+    clock = pygame.time.Clock()
+
+    # Initialise joysticks
+    pygame.joystick.init()
+    for i in range(pygame.joystick.get_count()):
+        pygame.joystick.Joystick(i).init()
+
+    bird = pygame.Rect(50, HEIGHT // 2, 30, 30)
+    velocity = 0
+    gravity = 0.5
+    jump = -8
+
+    pipes = []
+    pipe_gap = 150
+    pipe_speed = 3
+    spawn_timer = 0
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN and event.key in (pygame.K_SPACE, pygame.K_UP):
+                velocity = jump
+            elif event.type == pygame.JOYBUTTONDOWN:
+                velocity = jump
+
+        spawn_timer += 1
+        if spawn_timer > 90:
+            spawn_timer = 0
+            center = random.randrange(100, HEIGHT - 100)
+            top = pygame.Rect(WIDTH, 0, 50, center - pipe_gap // 2)
+            bottom = pygame.Rect(WIDTH, center + pipe_gap // 2, 50, HEIGHT - (center + pipe_gap // 2))
+            pipes.append((top, bottom))
+
+        velocity += gravity
+        bird.y += int(velocity)
+
+        for top, bottom in pipes:
+            top.x -= pipe_speed
+            bottom.x -= pipe_speed
+        pipes = [p for p in pipes if p[0].right > 0]
+
+        for top, bottom in pipes:
+            if bird.colliderect(top) or bird.colliderect(bottom):
+                running = False
+        if bird.top < 0 or bird.bottom > HEIGHT:
+            running = False
+
+        screen.fill(BACKGROUND)
+        pygame.draw.rect(screen, BIRD_COLOR, bird)
+        for top, bottom in pipes:
+            pygame.draw.rect(screen, PIPE_COLOR, top)
+            pygame.draw.rect(screen, PIPE_COLOR, bottom)
+        pygame.display.flip()
+
+        clock.tick(60)
+
+    game_over(screen, clock)
+
+
+def game_over(screen, clock):
+    """Display a game over screen waiting for user input."""
+    font_size = 48
+    font = pygame.font.SysFont(None, font_size)
+    msg = font.render("Game Over - Press Enter or Button", True, (255, 255, 255))
+    while msg.get_width() > WIDTH - 20 and font_size > 10:
+        font_size -= 2
+        font = pygame.font.SysFont(None, font_size)
+        msg = font.render("Game Over - Press Enter or Button", True, (255, 255, 255))
+    rect = msg.get_rect(center=(WIDTH // 2, HEIGHT // 2))
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    waiting = False
+            elif event.type == pygame.JOYBUTTONDOWN:
+                waiting = False
+
+        screen.fill((0, 0, 0))
+        screen.blit(msg, rect)
+        pygame.display.flip()
+        clock.tick(15)
+

--- a/games/snake.py
+++ b/games/snake.py
@@ -1,0 +1,153 @@
+import random
+import sys
+import pygame
+
+CELL_SIZE = 20
+GRID_WIDTH = 30
+GRID_HEIGHT = 30
+SCREEN_WIDTH = CELL_SIZE * GRID_WIDTH
+SCREEN_HEIGHT = CELL_SIZE * GRID_HEIGHT
+BACKGROUND = (0, 0, 0)
+SNAKE_COLOR = (0, 255, 0)
+FOOD_COLOR = (255, 0, 0)
+
+
+# Mapping of opposite directions to avoid reversal
+OPPOSITES = {
+    (1, 0): (-1, 0),
+    (-1, 0): (1, 0),
+    (0, 1): (0, -1),
+    (0, -1): (0, 1),
+}
+
+
+def run():
+    """Run a simple snake game controlled by keyboard or joystick."""
+    screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+    pygame.display.set_caption("Snake")
+    clock = pygame.time.Clock()
+
+    # Initialise joysticks
+    pygame.joystick.init()
+    joysticks = []
+    for i in range(pygame.joystick.get_count()):
+        js = pygame.joystick.Joystick(i)
+        js.init()
+        joysticks.append(js)
+
+    snake = [(GRID_WIDTH // 2, GRID_HEIGHT // 2)]
+    direction = (1, 0)
+    food = (random.randrange(GRID_WIDTH), random.randrange(GRID_HEIGHT))
+
+    alive = True
+    while alive:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_UP, pygame.K_w):
+                    new_dir = (0, -1)
+                elif event.key in (pygame.K_DOWN, pygame.K_s):
+                    new_dir = (0, 1)
+                elif event.key in (pygame.K_LEFT, pygame.K_a):
+                    new_dir = (-1, 0)
+                elif event.key in (pygame.K_RIGHT, pygame.K_d):
+                    new_dir = (1, 0)
+                else:
+                    new_dir = direction
+                if new_dir != OPPOSITES.get(direction):
+                    direction = new_dir
+            elif event.type == pygame.JOYHATMOTION:
+                x, y = event.value
+                if x == 1:
+                    new_dir = (1, 0)
+                elif x == -1:
+                    new_dir = (-1, 0)
+                elif y == 1:
+                    new_dir = (0, 1)
+                elif y == -1:
+                    new_dir = (0, -1)
+                else:
+                    new_dir = direction
+                if new_dir != OPPOSITES.get(direction):
+                    direction = new_dir
+            elif event.type == pygame.JOYAXISMOTION:
+                if event.axis == 0:
+                    if event.value > 0.5:
+                        new_dir = (1, 0)
+                    elif event.value < -0.5:
+                        new_dir = (-1, 0)
+                    else:
+                        new_dir = direction
+                elif event.axis == 1:
+                    if event.value > 0.5:
+                        new_dir = (0, 1)
+                    elif event.value < -0.5:
+                        new_dir = (0, -1)
+                    else:
+                        new_dir = direction
+                else:
+                    new_dir = direction
+                if new_dir != OPPOSITES.get(direction):
+                    direction = new_dir
+
+        # Move snake
+        head_x, head_y = snake[0]
+        new_head = ((head_x + direction[0]) % GRID_WIDTH,
+                    (head_y + direction[1]) % GRID_HEIGHT)
+
+        if new_head in snake:
+            alive = False
+            break
+        snake.insert(0, new_head)
+
+        if new_head == food:
+            while food in snake:
+                food = (random.randrange(GRID_WIDTH), random.randrange(GRID_HEIGHT))
+        else:
+            snake.pop()
+
+        # Draw
+        screen.fill(BACKGROUND)
+        for x, y in snake:
+            rect = pygame.Rect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE)
+            pygame.draw.rect(screen, SNAKE_COLOR, rect)
+        fx, fy = food
+        food_rect = pygame.Rect(fx * CELL_SIZE, fy * CELL_SIZE, CELL_SIZE, CELL_SIZE)
+        pygame.draw.rect(screen, FOOD_COLOR, food_rect)
+        pygame.display.flip()
+
+        clock.tick(10)
+
+    game_over(screen, clock)
+
+
+def game_over(screen, clock):
+    """Display a game over screen waiting for user input."""
+    font_size = 48
+    font = pygame.font.SysFont(None, font_size)
+    msg = font.render("Game Over - Press Enter or Button", True, (255, 255, 255))
+    while msg.get_width() > SCREEN_WIDTH - 20 and font_size > 10:
+        font_size -= 2
+        font = pygame.font.SysFont(None, font_size)
+        msg = font.render("Game Over - Press Enter or Button", True, (255, 255, 255))
+    rect = msg.get_rect(center=(SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2))
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    waiting = False
+            elif event.type == pygame.JOYBUTTONDOWN:
+                waiting = False
+
+        screen.fill((0, 0, 0))
+        screen.blit(msg, rect)
+        pygame.display.flip()
+        clock.tick(15)
+


### PR DESCRIPTION
## Summary
- add Checkers game with keyboard and controller support
- include Checkers in hub menu alongside Snake and Flappy Bird
- ensure game-over text scales to fit each game's window

## Testing
- `python -m py_compile gamehub.py games/snake.py games/flappy.py games/checkers.py`
- ⚠️ `SDL_VIDEODRIVER=dummy python - <<'PY' ...` (pygame missing)


------
https://chatgpt.com/codex/tasks/task_e_68a0af572f748326af5710280c97f95a